### PR TITLE
Bug 959816 - Improve mocha-tbpl-reporter error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ before_install:
   - "sudo easy_install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
 language: node_js
 node_js:
-  - "0.6"
-  - "0.8"
   - "0.10"

--- a/lib/tbpl.js
+++ b/lib/tbpl.js
@@ -1,4 +1,3 @@
-
 var Base = require('mocha').reporters.Base;
 
 
@@ -10,12 +9,18 @@ var Base = require('mocha').reporters.Base;
 function TBPL(runner) {
   Base.call(this, runner);
 
-  runner.on('end', this.onEnd.bind(this));
-  runner.on('fail', this.onFail.bind(this));
-  runner.on('pass', this.onPass.bind(this));
-  runner.on('pending', this.onPending.bind(this));
-  runner.on('test', this.onTest.bind(this));
-  runner.on('test end', this.onTestEnd.bind(this));
+  this.onEnd = this.onEnd.bind(this);
+  runner.on('end', this.onEnd);
+  this.onFail = this.onFail.bind(this);
+  runner.on('fail', this.onFail);
+  this.onPass = this.onPass.bind(this);
+  runner.on('pass', this.onPass);
+  this.onPending = this.onPending.bind(this);
+  runner.on('pending', this.onPending);
+  this.onTest = this.onTest.bind(this);
+  runner.on('test', this.onTest);
+  this.onTestEnd = this.onTestEnd.bind(this);
+  runner.on('test end', this.onTestEnd);
 
   this.failing = 0;
   this.passing = 0;
@@ -25,6 +30,8 @@ module.exports = TBPL;
 
 
 TBPL.prototype = {
+  __proto__: Base.prototype,
+
   /**
    * Number of failing tests.
    * @type {number}
@@ -51,6 +58,7 @@ TBPL.prototype = {
     console.log('passed: %d', this.passing);
     console.log('failed: %d', this.failing);
     console.log('todo: %d', this.pending);
+    this.epilogue();
   },
 
   /**
@@ -60,6 +68,7 @@ TBPL.prototype = {
   onFail: function(test, err) {
     var title = this.getTitle(test);
     console.log('TEST-UNEXPECTED-FAIL | %s', title);
+    console.log(err.message);
     this.failing += 1;
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-tbpl-reporter",
-  "version": "0.0.5",
+  "version": "0.0.6",
 
   "author": "Gareth Aye <gaye@mozilla.com>",
   "description": "Mocha reporter for TBPL (tinderboxpushlog)",

--- a/test/tbpl_test.js
+++ b/test/tbpl_test.js
@@ -1,112 +1,100 @@
-
 var TBPL = require('../lib/tbpl'),
     assert = require('assert'),
     sinon = require('sinon');
 
 suite('TBPL', function() {
-  var runner, spy, subject;
+  var runner, on, log;
 
   setup(function() {
     runner = {
       on: function(type, listener) {}
     };
 
-    spy = sinon.spy(runner, 'on');
+    on = sinon.spy(runner, 'on');
+    log = sinon.spy(console, 'log');
     subject = new TBPL(runner);
   });
 
+  teardown(function() {
+    on.restore();
+    log.restore();
+  });
+
   test('#constructor', function() {
-    sinon.assert.calledWith(spy, 'end');
-    sinon.assert.calledWith(spy, 'fail');
-    sinon.assert.calledWith(spy, 'pass');
-    sinon.assert.calledWith(spy, 'pending');
-    sinon.assert.calledWith(spy, 'test');
-    sinon.assert.calledWith(spy, 'test end');
+    sinon.assert.calledWith(on, 'end');
+    sinon.assert.calledWith(on, 'fail');
+    sinon.assert.calledWith(on, 'pass');
+    sinon.assert.calledWith(on, 'pending');
+    sinon.assert.calledWith(on, 'test');
+    sinon.assert.calledWith(on, 'test end');
     assert.strictEqual(subject.failing, 0);
     assert.strictEqual(subject.passing, 0);
     assert.strictEqual(subject.pending, 0);
   });
 
   test('#onEnd', function() {
-    var stub = sinon.stub(console, 'log');
     subject.onEnd();
-    console.log.restore();
-
-    assert.ok(stub.calledWith('*~*~* Results *~*~*'));
-    assert.ok(stub.calledWith('passed: %d', 0));
-    assert.ok(stub.calledWith('failed: %d', 0));
-    assert.ok(stub.calledWith('todo: %d', 0));
+    assert.ok(log.calledWith('*~*~* Results *~*~*'));
+    assert.ok(log.calledWith('passed: %d', 0));
+    assert.ok(log.calledWith('failed: %d', 0));
+    assert.ok(log.calledWith('todo: %d', 0));
   });
 
   test('#onFail', function() {
     var failing = subject.failing;
-    var stub = sinon.stub(console, 'log');
     subject.onFail({
       fullTitle: function() {
         return 'some title';
       }
-    });
-    console.log.restore();
+    }, new Error('ruhroh'));
 
     assert.strictEqual(subject.failing, failing + 1);
-    assert.ok(
-        stub.calledWith('TEST-UNEXPECTED-FAIL | %s', 'some title'));
+    assert.ok(log.calledWith('TEST-UNEXPECTED-FAIL | %s', 'some title'));
+    assert.ok(log.calledWith('ruhroh'));
   });
 
   test('#onPass', function() {
     var passing = subject.passing;
-    var stub = sinon.stub(console, 'log');
     subject.onPass({
       fullTitle: function() {
         return 'some title';
       }
     });
-    console.log.restore();
 
     assert.strictEqual(subject.passing, passing + 1);
-    assert.ok(
-        stub.calledWith('TEST-PASS | %s', 'some title'));
+    assert.ok(log.calledWith('TEST-PASS | %s', 'some title'));
   });
 
   test('#onPending', function() {
     var pending = subject.pending;
-    var stub = sinon.stub(console, 'log');
     subject.onPending({
       fullTitle: function() {
         return 'some title';
       }
     });
-    console.log.restore();
 
     assert.strictEqual(subject.pending, pending + 1);
-    assert.ok(
-        stub.calledWith('TEST-PENDING | %s', 'some title'));
+    assert.ok(log.calledWith('TEST-PENDING | %s', 'some title'));
   });
 
   test('#onTest', function() {
-    var stub = sinon.stub(console, 'log');
     subject.onTest({
       fullTitle: function() {
         return 'some title';
       }
     });
-    console.log.restore();
 
-    assert.ok(
-        stub.calledWith('TEST-START | %s', 'some title'));
+    assert.ok(log.calledWith('TEST-START | %s', 'some title'));
   });
 
   test('#onTestEnd', function() {
-    var stub = sinon.stub(console, 'log');
     subject.onTestEnd({
       fullTitle: function() {
         return 'some title';
       }
     });
-    console.log.restore();
 
-    assert.ok(
-        stub.calledWith('TEST-END | %s', 'some title'));
+    assert.ok(log.calledWith('TEST-END | %s', 'some title'));
   });
 
   test('#getTitle', function() {


### PR DESCRIPTION
### Summary
- Print mocha's base epilogue when the tests end
- Print error messages as they come in
- Clean up test suite
- Bump version to 0.0.6
